### PR TITLE
:herb: Fix webhook verification import path

### DIFF
--- a/webhooks/client/verify_signature.go
+++ b/webhooks/client/verify_signature.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"hash"
 
-	"github.com/fern-demo/square-go-sdk"
+	"github.com/square/square-go-sdk"
 )
 
 // VerifySignature verifies and validates an event notification.


### PR DESCRIPTION
This updates the import path used in the custom webhook verification method. This repository was moved from another module, so the import path was not updated due to the [.fernignore](https://github.com/square/square-go-sdk/blob/4ad54293081c8c1ae5e02ae2e19c59665d7d32b6/.fernignore#L4) file.