### PR TITLE
:herb: Add Apache 2.0 license

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,5 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
+LICENSE
 README.md
 
 # Hand-written integration tests.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,10 @@
+Copyright 2024 Square, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+   https://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Square Go Library
 
-[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-SDK%20generated%20by%20Fern-brightgreen)](https://github.com/fern-api/fern)
+[![fern shield](https://img.shields.io/badge/%F0%9F%8C%BF-Built%20with%20Fern-brightgreen)](https://buildwithfern.com)
 [![go shield](https://img.shields.io/badge/go-docs-blue)](https://pkg.go.dev/github.com/square/square-go-sdk)
 
 The Square Go library provides convenient access to the Square API from Go.


### PR DESCRIPTION
This adds the Apache 2.0 license, which is used in Square's other SDKs (e.g. [PHP](https://github.com/square/square-php-sdk/blob/230d8d80ba866cf99faa8d7b9f8a204ccd7a7c61/LICENSE#L1)). This also updates the Fern badge content and link.