### PR TITLE
:herb: Fix client.Webhooks.VerifySignature

### DIFF
--- a/webhooks/client/verify_signature.go
+++ b/webhooks/client/verify_signature.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
-	"encoding/hex"
+	"encoding/base64"
 	"errors"
 	"hash"
 
@@ -47,7 +47,7 @@ func createHmac(data, key string) (string, error) {
 	if _, err := h.Write([]byte(data)); err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return base64.StdEncoding.EncodeToString(h.Sum(nil)), nil
 }
 
 func timingSafeEqual(a, b string) bool {

--- a/webhooks/client/verify_signature_test.go
+++ b/webhooks/client/verify_signature_test.go
@@ -11,7 +11,7 @@ import (
 func TestWebhookSignatureValidation(t *testing.T) {
 	validRequest := &square.VerifySignatureRequest{
 		RequestBody:     `{"merchant_id":"MLEFBHHSJGVHD","type":"webhooks.test_notification","event_id":"ac3ac95b-f97d-458c-a6e6-18981597e05f","created_at":"2022-07-13T20:30:59.037339943Z","data":{"type":"webhooks","id":"bc368e64-01aa-407e-b46e-3231809b1129"}}`,
-		SignatureHeader: "185e1892b2601810d9f4d2186cd5c19cccea6f61e82f8456fd2eaf919f7fd8de",
+		SignatureHeader: "GF4YkrJgGBDZ9NIYbNXBnMzqb2HoL4RW/S6vkZ9/2N4=",
 		SignatureKey:    "Ibxx_5AKakO-3qeNVR61Dw",
 		NotificationURL: "https://webhook.site/679a4f3a-dcfa-49ee-bac5-9d0edad886b9",
 	}
@@ -33,7 +33,7 @@ func TestWebhookSignatureValidation(t *testing.T) {
 			description: "unescaped chars validation should pass",
 			request: &square.VerifySignatureRequest{
 				RequestBody:     `{"data":{"type":"webhooks","id":"fake_id"}}`,
-				SignatureHeader: `5b716508d939200dd94362c74d6a1a8efcdf683bbf3b0636b4d1c81c2dc850e0`,
+				SignatureHeader: `W3FlCNk5IA3ZQ2LHTWoajvzfaDu/OwY2tNHIHC3IUOA=`,
 				SignatureKey:    "signature-key",
 				NotificationURL: "https://webhook.site/webhooks",
 			},
@@ -42,7 +42,7 @@ func TestWebhookSignatureValidation(t *testing.T) {
 			description: "escaped characters should pass",
 			request: &square.VerifySignatureRequest{
 				RequestBody:     `{"data":{"type":"webhooks","id":">id<"}}`,
-				SignatureHeader: `0b1b7bf9a4e2e2b2a0700d1b0b883d107755b4b48359da9c7262f932f8a15385`,
+				SignatureHeader: `Cxt7+aTi4rKgcA0bC4g9EHdVtLSDWdqccmL5MvihU4U=`,
 				SignatureKey:    "signature-key",
 				NotificationURL: "https://webhook.site/webhooks",
 			},


### PR DESCRIPTION
Fixes https://github.com/square/square-go-sdk/issues/24

This updates the `client.Webhooks.VerifySignature` method to use base64 encoding, which is consistent with Square's API (documented [here](https://developer.squareup.com/docs/webhooks/overview)), as well as [Square's Node SDK](https://github.com/square/square-nodejs-sdk/blob/3f7d17a2edfdef82703f0eb3b62231bb9247fa0f/src/utilities/webhooksHelper.ts#L42).